### PR TITLE
Use OMERODIR if OMERO_HOME not set

### DIFF
--- a/omeroweb/settings.py
+++ b/omeroweb/settings.py
@@ -58,6 +58,8 @@ if not py27_only():
 # handler404 and handler500 works only when False
 if 'OMERO_HOME' in os.environ:
     OMERO_HOME = os.environ.get('OMERO_HOME')
+elif 'OMERODIR' in os.environ:
+    OMERO_HOME = os.environ.get('OMERODIR')
 else:
     OMERO_HOME = os.path.join(os.path.dirname(__file__), '..', '..', '..')
     OMERO_HOME = os.path.normpath(OMERO_HOME)


### PR DESCRIPTION
Use OMERODIR if OMERO_HOME not set in omeroweb/settings.py

Do we want to remove ```OMERO_HOME``` usage completely (ignore even if it's set)?