### PR TITLE
Allow 'dev' and other prefixes in version

### DIFF
--- a/omeroweb/webclient/views.py
+++ b/omeroweb/webclient/views.py
@@ -261,7 +261,7 @@ class WebclientLoginView(LoginView):
 
         context['show_download_links'] = settings.SHOW_CLIENT_DOWNLOADS
         if settings.SHOW_CLIENT_DOWNLOADS:
-            ver = re.match('(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).*',
+            ver = re.match('(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>(a|b|dev|rc)?\d+).*',
                            omero_version)
             client_download_tag_re = '^v%s\\.%s\\.[^-]+$' % (
                 ver.group('major'), ver.group('minor'))


### PR DESCRIPTION
Similar to https://github.com/ome/omero-marshal/pull/61
Allow version e.g. ```5.5.dev1``` etc.